### PR TITLE
LIBFCREPO-114. Client and server certs.

### DIFF
--- a/classes/pcdm.py
+++ b/classes/pcdm.py
@@ -54,14 +54,22 @@ class Repository():
         elif 'FEDORA_USER' in config and 'FEDORA_PASSWORD' in config:
             self.auth = (config['FEDORA_USER'], config['FEDORA_PASSWORD'])
 
+        if 'SERVER_CERT' in config:
+            self.server_cert = config['SERVER_CERT']
+        else:
+            self.server_cert = None
+
     def post(self, url, **kwargs):
-        return requests.post(url, cert=self.client_cert, auth=self.auth, **kwargs)
+        return requests.post(url, cert=self.client_cert, auth=self.auth,
+                verify=self.server_cert, **kwargs)
 
     def patch(self, url, **kwargs):
-        return requests.patch(url, cert=self.client_cert, auth=self.auth, **kwargs)
+        return requests.patch(url, cert=self.client_cert, auth=self.auth,
+                verify=self.server_cert, **kwargs)
 
     def head(self, url, **kwargs):
-        return requests.head(url, cert=self.client_cert, auth=self.auth, **kwargs)
+        return requests.head(url, cert=self.client_cert, auth=self.auth,
+                verify=self.server_cert, **kwargs)
 
 
 #============================================================================

--- a/classes/pcdm.py
+++ b/classes/pcdm.py
@@ -46,19 +46,22 @@ namespace_manager.bind('rdf', rdf, override=False)
 class Repository():
     def __init__(self, config):
         self.endpoint = config['REST_ENDPOINT']
-        if 'FEDORA_USER' in config and 'FEDORA_PASSWORD' in config:
+        self.auth = None
+        self.client_cert = None
+
+        if 'CLIENT_CERT' in config and 'CLIENT_KEY' in config:
+            self.client_cert = (config['CLIENT_CERT'], config['CLIENT_KEY'])
+        elif 'FEDORA_USER' in config and 'FEDORA_PASSWORD' in config:
             self.auth = (config['FEDORA_USER'], config['FEDORA_PASSWORD'])
-        else:
-            self.auth = ()
 
     def post(self, url, **kwargs):
-        return requests.post(url, auth=self.auth, **kwargs)
+        return requests.post(url, cert=self.client_cert, auth=self.auth, **kwargs)
 
     def patch(self, url, **kwargs):
-        return requests.patch(url, auth=self.auth, **kwargs)
+        return requests.patch(url, cert=self.client_cert, auth=self.auth, **kwargs)
 
     def head(self, url, **kwargs):
-        return requests.head(url, auth=self.auth, **kwargs)
+        return requests.head(url, cert=self.client_cert, auth=self.auth, **kwargs)
 
 
 #============================================================================
@@ -188,6 +191,7 @@ class Resource():
             component.graph.add( (component.uri, pcdm.memberOf, self.uri) )
 
         for file in self.files:
+            sys.stderr.write(str(self.uri))
             self.graph.add( (self.uri, pcdm.hasFile, file.uri) )
             file.graph.add( (file.uri, pcdm.fileOf, self.uri) )
 


### PR DESCRIPTION


* Added client certificate authentication that takes precedence over username and password authentication. Set the CLIENT_CERT and CLIENT_KEY values in the config file and Requests will use those files as the request certificate and key.
* For testing on repos with self-signed certificates (e.g., fcrepo-vagrant), added a SERVER_CERT config option to specify the server cert for Requests to trust when making HTTPS connections to the repository.

https://issues.umd.edu/browse/LIBFCREPO-114

