### PR TITLE
respect limit flag during preprocessing

### DIFF
--- a/classes/pcdm.py
+++ b/classes/pcdm.py
@@ -1,3 +1,4 @@
+from datetime import datetime as dt
 import hashlib
 from io import BytesIO
 import mimetypes
@@ -138,6 +139,7 @@ class Resource():
     def recursive_create(self, repository, nobinaries):
         if not self.exists_in_repo(repository):
             self.create_object(repository)
+            self.creation_timestamp = dt.now()
         else:
             print('Object "{0}" exists. Skipping...'.format(self.title))
 

--- a/handler/ndnp.py
+++ b/handler/ndnp.py
@@ -106,8 +106,8 @@ XPATHMAP = {
 # DATA LOADING FUNCTION
 #============================================================================
 
-def load(path_to_batch_xml):
-    return Batch(path_to_batch_xml)
+def load(args):
+    return Batch(args.path, args.limit)
 
 
 
@@ -119,7 +119,7 @@ class Batch():
 
     '''class representing the set of resources to be loaded'''
 
-    def __init__(self, batchfile):
+    def __init__(self, batchfile, limit):
         tree = ET.parse(batchfile)
         root = tree.getroot()
         m = XPATHMAP
@@ -151,10 +151,13 @@ class Batch():
 
         # iterate over the paths to the issues and create an item from each one
         for n, p in enumerate(self.paths):
-            print("Preprocessing item {0}/{1}...".format(n+1,
-                self.length), end='\r')
+            print("Preprocessing item {0}/{1}...".format(
+                n+1, self.length), end='\r'
+                )
             
-            # print(p)
+            if len(self.items) >= limit:
+                print("Stopping preprocessing after {0} items".format(limit))
+                break
             
             if not os.path.isfile(p[0]) or not os.path.isfile(p[1]):
                 print("\nMissing file for item {0}, skipping".format(n+1))


### PR DESCRIPTION
- respects the limit on objects set with the -l flag, not only during load, but also during preprocessing phase, which makes testing with small subsets of large batches much more efficient
- adds a creation timestamp to the mapfile for each item loaded
- passes the full set of args (rather than just the path) to the main batch load function, so all args are available when constructing the batch (necessary in particular so the limit would be available during preprocessing)
- refines the wording in a few comments