### PR TITLE
fix bug with empty limit and missing reel path attribute

### DIFF
--- a/handler/ndnp.py
+++ b/handler/ndnp.py
@@ -124,8 +124,6 @@ class Batch():
         root = tree.getroot()
         m = XPATHMAP
 
-        self.reel = Reel(batchfile)
-
         dback = Collection()
         dback.title = "The Diamondback Newspaper Collection"
         dback.graph.add(
@@ -144,6 +142,8 @@ class Batch():
                     )
                 )
         self.length = len(self.paths)
+        
+        self.reel = Reel(batchfile)
 
         print("Batch contains {} issues.".format(self.length))
 
@@ -155,7 +155,7 @@ class Batch():
                 n+1, self.length), end='\r'
                 )
             
-            if len(self.items) >= limit:
+            if limit is not None and len(self.items) >= limit:
                 print("Stopping preprocessing after {0} items".format(limit))
                 break
             
@@ -273,6 +273,9 @@ class Reel(pcdm.Item):
         self.id = elem.get('reelNumber')
         self.title = 'Reel Number {0}'.format(self.id)
         self.sequence_attr = ('Frame', 'frame')
+        self.basepath = os.path.dirname(batchfile)
+        self.path = os.path.join(self.basepath, elem.text)
+        print("Reel path = ", self.path)
 
         self.graph.add(
             (self.uri, dc.title, rdflib.Literal(self.title))

--- a/load.py
+++ b/load.py
@@ -89,7 +89,7 @@ def main():
 
     # Limit the load to a specified number of top-level objects
     parser.add_argument('-l', '--limit',
-                        help='''Limit the load to a specified number of             
+                        help='''Limit the load to a specified number of 
                                 top-level objects.''',
                         action='store',
                         type=int,


### PR DESCRIPTION
- adds the path attribute to the reel object (absolute local path to the reel XML), which allows the script to process batches that have been limited using the --limit flag
- checks if the limit is not none before comparing it to number of resources preprocessed to avoid error when comparing Nonetype to integer in cases where the limit is unset