### PR TITLE
handle multiple reels

### DIFF
--- a/classes/pcdm.py
+++ b/classes/pcdm.py
@@ -242,7 +242,9 @@ class Resource():
                 )
 
     def add_extra_properties(self, triples_file, rdf_format):
-        self.graph.parse(source=triples_file, format=rdf_format, publicID=self.uri)
+        self.graph.parse(
+            source=triples_file, format=rdf_format, publicID=self.uri
+            )
 
     # show the object's graph, serialized as turtle
     def print_graph(self):

--- a/classes/pcdm.py
+++ b/classes/pcdm.py
@@ -421,4 +421,3 @@ class Proxy(Resource):
         self.graph.add( (self.uri, dcterms.title, rdflib.Literal(self.title)) )
 
 
-

--- a/handler/ndnp.py
+++ b/handler/ndnp.py
@@ -172,22 +172,21 @@ class Batch():
 
 
     def __next__(self):
-        for i in self.issues:
-            if not os.path.isfile(i[0]) or not os.path.isfile(i[1]):
-                print("\nMissing file for item {0}, skipping".format(
-                    self.num + 1
-                    ))
-                continue
-            issue = Issue(i)
+        total_length = len(self.issues) + len(self.reels)
+        if self.num < len(self.issues):
+            n = self.num
+            issue = Issue(self.issues[n])
             # add the collection to the issue
             issue.collections.append(self.collection)
+            self.num += 1
             return issue
-        
-        for r in self.reels:
-            return Reel(r)           
-        
-        print('\nProcessing complete!')
-        raise StopIteration()
+        elif self.num >= len(self.issues) and self.num < total_length:
+            n = self.num - len(self.issues)
+            self.num += 1
+            return Reel(self.reels[n])
+        else:
+            print('\nProcessing complete!')
+            raise StopIteration()
 
 
 
@@ -260,6 +259,12 @@ class Issue(pcdm.Item):
         article_root = article_tree.getroot()
         for article_title in article_root.findall(m['article']):
             self.related.append(Article(article_title.text, self))
+
+
+    def get_component_info(self):
+        return ["{0};{1};{2}".format(
+                    page.reel, page.frame, str(page.uri)
+                    ) for page in self.components]
 
 
 
@@ -396,4 +401,6 @@ class Article(pcdm.Item):
         self.graph.namespace_manager = namespace_manager
         self.graph.add( (self.uri, dcterms.title, rdflib.Literal(self.title)) )
         self.graph.add( (self.uri, rdf.type, bibo.Article) )
+
+
 

--- a/load.py
+++ b/load.py
@@ -185,7 +185,7 @@ def main():
                 print('')
                 print('=' * 80)
                 print('')
-                print("Processing item {0}/{1}...".format(n + 1, batch.length))
+                print("Processing item {0}/{1}...".format(n+1, batch.length))
                 item.print_item_tree()
                 print('\nLoading item {0}...'.format(n+1))
                 item.recursive_create(fcrepo, args.nobinaries)

--- a/load.py
+++ b/load.py
@@ -148,7 +148,9 @@ def main():
         test_connection(fcrepo)
 
         # open mapfile, if it exists, and read completed files into list
-        fieldnames = ['number', 'timestamp', 'title', 'path', 'uri']
+        fieldnames = ['number', 'timestamp', 'title', 
+                      'path', 'uri', 'components'
+                      ]
         completed_items = []
         skip_list = []
         if os.path.isfile(args.map):
@@ -210,7 +212,8 @@ def main():
                        'timestamp': item.creation_timestamp,
                        'title': item.title,
                        'path': item.path,
-                       'uri': item.uri
+                       'uri': item.uri,
+                       'components': item.get_component_info()
                        }
                 writer.writerow(row)
 

--- a/load.py
+++ b/load.py
@@ -148,9 +148,7 @@ def main():
         test_connection(fcrepo)
 
         # open mapfile, if it exists, and read completed files into list
-        fieldnames = ['number', 'timestamp', 'title', 
-                      'path', 'uri', 'components'
-                      ]
+        fieldnames = ['number', 'timestamp', 'title', 'path', 'uri']
         completed_items = []
         skip_list = []
         if os.path.isfile(args.map):
@@ -212,8 +210,7 @@ def main():
                        'timestamp': item.creation_timestamp,
                        'title': item.title,
                        'path': item.path,
-                       'uri': item.uri,
-                       'components': item.get_component_info()
+                       'uri': item.uri
                        }
                 writer.writerow(row)
 


### PR DESCRIPTION
This PR resolves part of LIBFCREPO-226:  it deals with batches containing multiple reels.

It does not yet handle reel creation for interrupted batches, since it works by keeping the pages created for the issues in memory until it is time to create the reel.

A further improvement would be to read page URIs for previously created items out of the mapfile and add those pages to the reel object.  This would allow reels to be created even when the batch had been interrupted.