### PR TITLE
Article members

### DIFF
--- a/classes/pcdm.py
+++ b/classes/pcdm.py
@@ -57,7 +57,9 @@ class Repository():
         self.auth = None
         self.client_cert = None
         self.transaction = None
-        self.logger = logging.getLogger(__name__ + '.' + self.__class__.__name__)
+        self.logger = logging.getLogger(
+            __name__ + '.' + self.__class__.__name__
+            )
 
         if 'CLIENT_CERT' in config and 'CLIENT_KEY' in config:
             self.client_cert = (config['CLIENT_CERT'], config['CLIENT_KEY'])
@@ -131,17 +133,23 @@ class Repository():
     def commit_transaction(self, **kwargs):
         if self.transaction is not None:
             url = os.path.join(self.transaction, 'fcr:tx/fcr:commit')
-            self.logger.info("Commiting transaction {0}".format(self.transaction))
+            self.logger.info(
+                "Commiting transaction {0}".format(self.transaction)
+                )
             self.logger.debug("POST {0}".format(url))
             response = requests.post(url, cert=self.client_cert, auth=self.auth,
                         verify=self.server_cert, **kwargs)
             self.logger.debug("%s %s", response.status_code, response.reason)
             if response.status_code == 204:
-                self.logger.info("Committed transaction {0}".format(self.transaction))
+                self.logger.info(
+                    "Committed transaction {0}".format(self.transaction)
+                    )
                 self.transaction = None
                 return True
             else:
-                self.logger.error("Failed to commit transaction {0}".format(self.transaction))
+                self.logger.error(
+                    "Failed to commit transaction {0}".format(self.transaction)
+                    )
                 raise RESTAPIException(response)
 
     def rollback_transaction(self, **kwargs):
@@ -188,7 +196,9 @@ class Resource(object):
         self.graph.namespace_manager = namespace_manager
         self.uri = rdflib.URIRef(uri)
         self.related = []
-        self.logger = logging.getLogger(__name__ + '.' + self.__class__.__name__)
+        self.logger = logging.getLogger(
+            __name__ + '.' + self.__class__.__name__
+            )
 
     # create repository object by POSTing object graph
     def create_object(self, repository):
@@ -244,33 +254,47 @@ class Resource(object):
             self.create_object(repository)
             self.creation_timestamp = dt.now()
         else:
-            self.logger.info('Object "{0}" exists. Skipping.'.format(self.title))
+            self.logger.info(
+                'Object "{0}" exists. Skipping.'.format(self.title)
+                )
 
         if not nobinaries:
             for file in self.files:
                 if not file.exists_in_repo(repository):
                     file.create_nonrdf(repository)
                 else:
-                    self.logger.info('File "{0}" exists. Skipping.'.format(file.title))
+                    self.logger.info(
+                        'File "{0}" exists. Skipping.'.format(file.title)
+                        )
 
         for component in self.components:
             if not component.exists_in_repo(repository):
                 component.recursive_create(repository, nobinaries)
             else:
-                self.logger.info('Component "{0}" exists. Skipping.'.format(component.title))
+                self.logger.info(
+                    'Component "{0}" exists. Skipping.'.format(component.title)
+                    )
 
         for related_object in self.related:
             if not related_object.exists_in_repo(repository):
                 related_object.recursive_create(repository, nobinaries)
             else:
-                self.logger.info('Related object "{0}" exists. Skipping.'.format(related_object.title))
+                self.logger.info(
+                    'Related object "{0}" exists. Skipping.'.format(
+                        related_object.title
+                        )
+                    )
 
         if hasattr(self, 'collections'):
             for collection in self.collections:
                 if not collection.exists_in_repo(repository):
                     collection.create_object(repository)
                 else:
-                    self.logger.info('Collection "{0}" exists. Skipping.'.format(collection.title))
+                    self.logger.info(
+                        'Collection "{0}" exists. Skipping.'.format(
+                            collection.title
+                            )
+                        )
 
     # recursively update an object and all its components and files
     def recursive_update(self, repository, nobinaries):
@@ -430,7 +454,9 @@ class File(Resource):
                    'Content-Disposition':
                         'attachment; filename="{0}"'.format(self.filename)
                     }
-        target_uri = '/'.join([p.strip('/') for p in (repository.endpoint, repository.relpath)])
+        target_uri = '/'.join(
+            [p.strip('/') for p in (repository.endpoint, repository.relpath)]
+            )
         response = repository.post(target_uri, data=data, headers=headers)
         if response.status_code == 201:
             self.uri = rdflib.URIRef(response.text)

--- a/classes/pcdm.py
+++ b/classes/pcdm.py
@@ -393,10 +393,8 @@ class Item(Resource):
             position = " ".join([self.sequence_attr[0],
                                 getattr(component, self.sequence_attr[1])]
                                 )
-            print(position)
             proxies.append(Proxy(position, self.title))
 
-        print(proxies)
         for proxy in proxies:
             proxy.create_object(repository)
             proxy.graph.namespace_manager = self.graph.namespace_manager

--- a/classes/pcdm.py
+++ b/classes/pcdm.py
@@ -388,17 +388,20 @@ class Item(Resource):
     # iterate over each component and create ordering proxies
     def create_ordering(self, repository):
         proxies = []
-        for component in self.components:
+        ordered_components = [c for c in self.components if c.ordered is True]
+        for component in ordered_components:
             position = " ".join([self.sequence_attr[0],
                                 getattr(component, self.sequence_attr[1])]
                                 )
+            print(position)
             proxies.append(Proxy(position, self.title))
 
+        print(proxies)
         for proxy in proxies:
             proxy.create_object(repository)
             proxy.graph.namespace_manager = self.graph.namespace_manager
 
-        for (position, component) in enumerate(self.components):
+        for (position, component) in enumerate(ordered_components):
             proxy = proxies[position]
             proxy.graph.add( (proxy.uri, ore.proxyFor, component.uri) )
             proxy.graph.add( (proxy.uri, ore.proxyIn, self.uri) )
@@ -409,7 +412,7 @@ class Item(Resource):
                 prev = proxies[position - 1]
                 proxy.graph.add( (proxy.uri, iana.prev, prev.uri) )
 
-            if position == len(self.components) - 1:
+            if position == len(ordered_components) - 1:
                 self.graph.add( (self.uri, iana.last, proxy.uri) )
             else:
                 next = proxies[position + 1]
@@ -428,6 +431,7 @@ class Component(Resource):
         self.files = []
         self.components = []
         self.collections = []
+        self.ordered = False
         self.graph.add( (self.uri, rdf.type, pcdm.Object) )
 
 #============================================================================

--- a/handler/ndnp.py
+++ b/handler/ndnp.py
@@ -164,8 +164,8 @@ class Batch():
             self.collection.uri, headers={'Accept': 'application/rdf+xml'}
             )
         if response.status_code == 200:
-            self.collection.title = '[unspecified]'
             coll_graph = rdflib.graph.Graph().parse(data=response.text)
+            self.collection.title = str(self.collection.uri)
             for (subj, pred, obj) in coll_graph:
                 if str(pred) == "http://purl.org/dc/elements/1.1/title":
                     self.collection.title = obj

--- a/handler/ndnp.py
+++ b/handler/ndnp.py
@@ -153,12 +153,16 @@ class Batch():
         self.batchfile = config.get('LOCAL_PATH')
         collection_uri = config.get('COLLECTION')
         if collection_uri is None:
-            raise ConfigException('Missing required key COLLECTION in batch config')
+            raise ConfigException(
+                'Missing required key COLLECTION in batch config'
+                )
         self.collection = Collection()
         self.collection.uri = rdflib.URIRef(collection_uri)
 
         # check that the supplied collection exists and get title
-        response = repo.get(self.collection.uri, headers={'Accept': 'application/rdf+xml'})
+        response = repo.get(
+            self.collection.uri, headers={'Accept': 'application/rdf+xml'}
+            )
         if response.status_code == 200:
             self.collection.title = '[unspecified]'
             coll_graph = rdflib.graph.Graph().parse(data=response.text)
@@ -166,7 +170,11 @@ class Batch():
                 if str(pred) == "http://purl.org/dc/elements/1.1/title":
                     self.collection.title = obj
         else:
-            raise ConfigException("Collection URI {0} could not be reached.".format(self.collection.uri))
+            raise ConfigException(
+                "Collection URI {0} could not be reached.".format(
+                    self.collection.uri
+                    )
+                )
 
         self.fieldnames = ['aggregation', 'sequence', 'uri']
 

--- a/handler/ndnp.py
+++ b/handler/ndnp.py
@@ -303,33 +303,7 @@ class Issue(pcdm.Item):
         article_tree = ET.parse(article_path)
         article_root = article_tree.getroot()
         for article_title in article_root.findall(m['article']):
-            self.related.append(Article(article_title.text, self))
-
-#============================================================================
-# NDNP REEL OBJECT
-#============================================================================
-
-class Reel(pcdm.Item):
-
-    ''' class representing an NDNP reel '''
-
-    def __init__(self, csvfile):
-        pcdm.Item.__init__(self)
-        self.id = csvfile
-        self.title = 'Reel Number {0}'.format(self.id)
-        self.sequence_attr = ('Frame', 'frame')
-        self.path = path
-        self.components = pages
-
-        self.graph.add(
-            (self.uri, dcterms.title, rdflib.Literal(self.title))
-            )
-        self.graph.add(
-            (self.uri, dc.identifier, rdflib.Literal(self.id))
-            )
-        self.graph.add(
-            (self.uri, rdf.type, carriers.hd)
-            )
+            self.components.append(Article(article_title.text, self))
 
 #============================================================================
 # NDNP PAGE OBJECT
@@ -350,6 +324,7 @@ class Page(pcdm.Component):
         self.frame    = pagexml.find(m['frame']).text
         self.title    = "{0}, page {1}".format(issue.title, self.number)
         self.reelpath = 'logs/reels/{0}.csv'.format(self.reel)
+        self.ordered  = True
 
         # generate a file object for each file in the XML snippet
         for f in filegroup.findall(m['files']):
@@ -438,15 +413,16 @@ class Collection(pcdm.Collection):
 # NDNP ARTICLE OBJECT
 #============================================================================
 
-class Article(pcdm.Item):
+class Article(pcdm.Component):
 
     ''' class representing an article in a newspaper issue '''
 
     def __init__(self, title, issue):
-        pcdm.Item.__init__(self)
+        pcdm.Component.__init__(self)
 
         # gather metadata
         self.title = title
+        self.ordered = False
 
         # store metadata in object graph
         self.graph.namespace_manager = namespace_manager

--- a/handler/reel.py
+++ b/handler/reel.py
@@ -96,9 +96,7 @@ class Batch():
                     self.collection.uri
                     )
                 )
-
-        
-        self.collections = [collection]
+        self.collections = [self.collection]
         self.path = batch_config.get('LOCAL_PATH')
         self.files = [os.path.join(self.path, f) for f in os.listdir(self.path)]
         self.length = len(self.files)
@@ -162,4 +160,5 @@ class Frame(pcdm.Component):
         self.frame = sequence
         self.uri = rdflib.URIRef(uri)
         self.title = "{0}, frame {1}".format(reel.title, self.frame)
+        self.ordered = True
 


### PR DESCRIPTION
- Changes the relations between issues and articles to pcdm:hasMember as opposed to pcdm:hasRelatedObject.
- Distinguishes between ordered and unordered members so proxies are not created for the latter.
- Removes the reel class from the ndnp handler since reels are now created in a separate handler.
- Provides clearer logging by pulling the title of the specified collection from Fedora and using that in log messages.
- Breaks some long lines according to Python convention.