### PR TITLE
Post trans

### DIFF
--- a/classes/pcdm.py
+++ b/classes/pcdm.py
@@ -369,14 +369,21 @@ class Resource(object):
     # show the item graph and tree of related objects
     def print_item_tree(self):
         print(self.title)
-        ordered_components = [c for c in self.components if c.ordered is True]
-        if self.components:
-            for n, p in enumerate(
-                
-                ):
+        ordered = [c for c in self.components if c.ordered is True]
+        unordered = [c for c in self.components if c.ordered is False]
+        if ordered:
+            print(" ORDERED COMPONENTS")
+            for n, p in enumerate(ordered):
                 print("  Part {0}: {1}".format(n+1, p.title))
                 for f in p.files:
                     print("   |--{0}: {1}".format(f.title, f.localpath))
+        if unordered:
+            print(" UNORDERED COMPONENTS")
+            for n, p in enumerate(unordered):
+                print("  - {1}".format(n+1, p.title))
+                for f in p.files:
+                    print("   |--{0}: {1}".format(f.title, f.localpath))
+
 
 #============================================================================
 # PCDM ITEM-OBJECT

--- a/classes/pcdm.py
+++ b/classes/pcdm.py
@@ -365,8 +365,11 @@ class Resource(object):
     # show the item graph and tree of related objects
     def print_item_tree(self):
         print(self.title)
+        ordered_components = [c for c in self.components if c.ordered is True]
         if self.components:
-            for n, p in enumerate(self.components):
+            for n, p in enumerate(
+                
+                ):
                 print("  Part {0}: {1}".format(n+1, p.title))
                 for f in p.files:
                     print("   |--{0}: {1}".format(f.title, f.localpath))

--- a/classes/pcdm.py
+++ b/classes/pcdm.py
@@ -134,7 +134,7 @@ class Repository():
         if self.transaction is not None:
             url = os.path.join(self.transaction, 'fcr:tx/fcr:commit')
             self.logger.info(
-                "Commiting transaction {0}".format(self.transaction)
+                "Committing transaction {0}".format(self.transaction)
                 )
             self.logger.debug("POST {0}".format(url))
             response = requests.post(url, cert=self.client_cert, auth=self.auth,
@@ -361,6 +361,10 @@ class Resource(object):
     # show the object's graph, serialized as turtle
     def print_graph(self):
         print(self.graph.serialize(format="turtle").decode())
+
+    # called after creation of object in repo
+    def post_creation_hook(self):
+        pass
 
     # show the item graph and tree of related objects
     def print_item_tree(self):

--- a/handler/ndnp.py
+++ b/handler/ndnp.py
@@ -337,7 +337,7 @@ class Page(pcdm.Component):
         self.graph.add( (self.uri, ndnp.sequence, rdflib.Literal(self.frame)) )
         self.graph.add( (self.uri, rdf.type, ndnp.Page) )
 
-    # populate non-atomic aggregation object via overloaded superclass method
+    '''# populate non-atomic aggregation object via overloaded superclass method
     def create_object(self, repository):
         if super(Page, self).create_object(repository):
             with open(self.reelpath, 'r') as f:
@@ -348,7 +348,7 @@ class Page(pcdm.Component):
                        'sequence':     self.frame,
                        'uri':          self.uri
                         }
-                writer.writerow(row)
+                writer.writerow(row)'''
 
 #============================================================================
 # NDNP FILE OBJECT

--- a/load.py
+++ b/load.py
@@ -76,6 +76,8 @@ def load_item(fcrepo, item, args, extra=None):
         # commit transaction
         logger.info('Committing transaction')
         fcrepo.commit_transaction()
+        logger.info('Performing post-creation actions')
+        item.post_creation_hook()
         return True
 
     except (pcdm.RESTAPIException, FileNotFoundError) as e:


### PR DESCRIPTION
- creates a post_creation_hook method to use for cleanup and other tasks after an item commit
- fixes the print_item_tree method to work with unordered components
- removes the old create_object method that wrote to the CSV during page creation