### PR TITLE
Data read error handler

### DIFF
--- a/handler/ndnp.py
+++ b/handler/ndnp.py
@@ -133,7 +133,7 @@ def load(repo, batch_config):
     return Batch(repo, batch_config)
 
 #============================================================================
-# NDNP BATCH CLASS
+# EXCEPTION CLASSES
 #============================================================================
 
 class ConfigException(Exception):
@@ -141,6 +141,15 @@ class ConfigException(Exception):
         self.message = message
     def __str__(self):
         return self.message
+
+class DataReadException(Exception):
+    def __init__(self, file):
+        self.message = "Error interpreting the data in {0}".format(file)
+    def __str__(self):
+        return self.message
+              #============================================================================
+# NDNP BATCH CLASS
+#============================================================================
 
 class Batch():
 
@@ -228,11 +237,13 @@ class Batch():
 
     def __next__(self):
         if self.num < self.length:
-            issue = Issue(self.issues[self.num])
+            data = self.issues[self.num]
+            issue = Issue(data)
             issue.collections.append(self.collection)
             self.num += 1
             return issue
         else:
+            print(self.num, self.length)
             self.logger.info('Processing complete!')
             raise StopIteration()
 
@@ -245,15 +256,21 @@ class Issue(pcdm.Item):
     ''' class representing all components of a newspaper issue '''
 
     def __init__(self, paths):
+        print('\n' + '*' * 80)
         (issue_path, article_path) = paths
+        print(issue_path)
         pcdm.Item.__init__(self)
-        tree = ET.parse(issue_path)
-        root = tree.getroot()
-        m = XPATHMAP['issue']
 
         # gather metadata
         self.dir            = os.path.dirname(issue_path)
         self.path           = issue_path
+        self.article_path   = article_path
+        
+    def read_data(self):
+        tree = ET.parse(self.path)
+        root = tree.getroot()
+        m = XPATHMAP['issue']
+    
         self.title          = root.xpath('./@LABEL')[0]
         self.volume         = root.find(m['volume']).text
         self.issue          = root.find(m['issue']).text
@@ -283,7 +300,11 @@ class Issue(pcdm.Item):
             )
 
         # gather all the page and file xml snippets
-        filexml_snippets = [f for f in root.findall(m['files'])]
+        filexml_snippets = {
+            elem.get('ID'): elem for elem in root.findall(m['files'])
+            }
+        print(filexml_snippets.items())
+        
         pagexml_snippets = [p for p in root.findall(m['pages']) if \
             p.get('ID').startswith('pageModsBib')
             ]
@@ -292,25 +313,25 @@ class Issue(pcdm.Item):
         premisxml = root.find(m['premis'])
         for n, pagexml in enumerate(pagexml_snippets):
             id = pagexml.get('ID').strip('pageModsBib')
-            filexml = next(
-                f for f in filexml_snippets if f.get('ID').endswith(id)
-                )
+            try:
+                filexml = filexml_snippets['pageFileGrp' + id]
+            except KeyError:
+                raise DataReadException(self.path)
 
             # create a page object for each page and append to list of pages
             page = Page(pagexml, filexml, premisxml, self)
             self.components.append(page)
 
-        # iterate over the article XML and create objects for issue's articles
-        article_tree = ET.parse(article_path)
+        # iterate over the article XML and create objects for articles
+        article_tree = ET.parse(self.article_path)
         article_root = article_tree.getroot()
         for article_title in article_root.findall(m['article']):
-            self.components.append(Article(article_title.text, self))
+            self.components.append(Article(article_title.text, self))    
 
     # actions to take upon successful creation of object in repository
     def post_creation_hook(self):
         super(pcdm.Item, self).post_creation_hook()
         pages = [c for c in self.components if c.ordered == True]
-        print(pages)
         for page in pages:
             row = {'aggregation': page.reel, 
                    'sequence': page.frame, 

--- a/handler/ndnp.py
+++ b/handler/ndnp.py
@@ -158,7 +158,6 @@ class Batch():
     def __init__(self, repo, config):
         self.logger = logging.getLogger(
             __name__ + '.' + self.__class__.__name__
-
             )
         self.batchfile = config.get('LOCAL_PATH')
         collection_uri = config.get('COLLECTION')
@@ -303,7 +302,6 @@ class Issue(pcdm.Item):
         filexml_snippets = {
             elem.get('ID'): elem for elem in root.findall(m['files'])
             }
-        print(filexml_snippets.items())
         
         pagexml_snippets = [p for p in root.findall(m['pages']) if \
             p.get('ID').startswith('pageModsBib')

--- a/load.py
+++ b/load.py
@@ -271,20 +271,19 @@ def main():
                         "Skipping item {0}: {1}".format(n, e.message)
                         )
 
-                # write item details to mapfile    
-                if is_loaded:
-                    row = {'number': n + 1,
-                       'timestamp': item.creation_timestamp,
+                row = {'number': n + 1,
                        'title': item.title,
                        'path': item.path,
-                       'uri': item.uri
+                       'timestamp': getattr(
+                            item, 'creation_timestamp', str(datetime.utcnow())
+                            ),
+                       'uri': getattr(item, 'uri', 'N/A')
                        }
+                       
+                # write item details to relevant summary CSV    
+                if is_loaded:
                     map_writer.writerow(row)
                 else:
-                    row = {'number': n + 1,
-                       'title': item.title,
-                       'path': item.path
-                       }
                     skip_writer.writerow(row)
                     
 

--- a/load.py
+++ b/load.py
@@ -49,6 +49,10 @@ def test_connection(fcrepo):
         sys.exit(1)
 
 def load_item(fcrepo, item, args, extra=None):
+    # read data for item
+    logger.info('Reading item data')
+    item.read_data()
+    
     # open transaction
     logger.info('Opening transaction')
     fcrepo.open_transaction()
@@ -222,19 +226,24 @@ def main():
                     skip_list = [row['path'] for row in completed_items]
 
         # open a new version of the map file
-        with open(mapfile, 'w+') as outfile:
-            writer = csv.DictWriter(outfile, fieldnames=fieldnames)
-            writer.writeheader()
+        with open(mapfile, 'w+', 1) as map, open(
+            'logs/skipped.csv', 'w+', 1) as skip:
+            map_writer = csv.DictWriter(map, fieldnames=fieldnames)
+            skip_writer = csv.DictWriter(skip, fieldnames=fieldnames)
+            map_writer.writeheader()
+            skip_writer.writeheader()
+            
             # write out completed items
             logger.info(
                 'Writing data for {0} existing items to mapfile.'.format(
                     len(completed_items))
-                    )
+                )
             for row in completed_items:
-                writer.writerow(row)
+                map_writer.writerow(row)
 
             # create all batch objects in repository
             for n, item in enumerate(batch):
+                is_loaded = False
                 if args.limit is not None and n >= args.limit:
                     logger.info("Stopping after {0} item(s)".format(args.limit))
                     break
@@ -257,16 +266,27 @@ def main():
                         "Unable to commit or rollback transaction, aborting"
                         )
                     sys.exit(1)
+                except handler.DataReadException as e:
+                    logger.error(
+                        "Skipping item {0}: {1}".format(n, e.message)
+                        )
 
+                # write item details to mapfile    
                 if is_loaded:
-                    # write item details to mapfile
                     row = {'number': n + 1,
-                           'timestamp': item.creation_timestamp,
-                           'title': item.title,
-                           'path': item.path,
-                           'uri': item.uri
-                           }
-                    writer.writerow(row)
+                       'timestamp': item.creation_timestamp,
+                       'title': item.title,
+                       'path': item.path,
+                       'uri': item.uri
+                       }
+                    map_writer.writerow(row)
+                else:
+                    row = {'number': n + 1,
+                       'title': item.title,
+                       'path': item.path
+                       }
+                    skip_writer.writerow(row)
+                    
 
     if not args.quiet:
         print_footer()


### PR DESCRIPTION
- creates a skipped.csv to record files that could not be loaded
- moves a lot of initial data loading out of the init() and into a read_data() method for the issue, in order that it can be wrapped in an exception handler
- creates an exception class for data reading errors

NOTE: There are a few print statements that remained behind after some debugging (in ndnp.Issue.init() and ndnp.batch.next() which may need to be taken out or converted to logging messages