### PR TITLE
make collection membership a one-way relationship

### DIFF
--- a/classes/pcdm.py
+++ b/classes/pcdm.py
@@ -342,7 +342,6 @@ class Resource(object):
 
         for collection in self.collections:
             self.graph.add( (self.uri, pcdm.memberOf, collection.uri) )
-            collection.graph.add( (collection.uri, pcdm.hasMember, self.uri) )
 
         for related_object in self.related:
             self.graph.add(


### PR DESCRIPTION
Omits adding the pcdm:hasMember predicate to the owning collection when creating PCDM objects. This should improve performance by avoiding one source of many-membered objects.

With this change committed, any Solr queries looking for collection membership will need to rely on the "[issue] pcdm:memberOf [collection]" relationship instead. Relationships between objects or between objects and files are still two-way relationships.