### PR TITLE
suppress unnecessary updates to collection object

### DIFF
--- a/classes/pcdm.py
+++ b/classes/pcdm.py
@@ -285,17 +285,6 @@ class Resource(object):
                         )
                     )
 
-        '''if hasattr(self, 'collections'):
-            for collection in self.collections:
-                if not collection.exists_in_repo(repository):
-                    collection.create_object(repository)
-                else:
-                    self.logger.info(
-                        'Collection "{0}" exists. Skipping.'.format(
-                            collection.title
-                            )
-                        )'''
-
     # recursively update an object and all its components and files
     def recursive_update(self, repository, nobinaries):
         self.update_object(repository)
@@ -306,9 +295,6 @@ class Resource(object):
             component.recursive_update(repository, nobinaries)
         for related_object in self.related:
             related_object.recursive_update(repository, nobinaries)
-        '''if hasattr(self, 'collections'):
-            for collection in self.collections:
-                collection.update_object(repository)'''
 
     # check for the existence of a local object in the repository
     def exists_in_repo(self, repository):

--- a/classes/pcdm.py
+++ b/classes/pcdm.py
@@ -285,7 +285,7 @@ class Resource(object):
                         )
                     )
 
-        if hasattr(self, 'collections'):
+        '''if hasattr(self, 'collections'):
             for collection in self.collections:
                 if not collection.exists_in_repo(repository):
                     collection.create_object(repository)
@@ -294,7 +294,7 @@ class Resource(object):
                         'Collection "{0}" exists. Skipping.'.format(
                             collection.title
                             )
-                        )
+                        )'''
 
     # recursively update an object and all its components and files
     def recursive_update(self, repository, nobinaries):
@@ -306,9 +306,9 @@ class Resource(object):
             component.recursive_update(repository, nobinaries)
         for related_object in self.related:
             related_object.recursive_update(repository, nobinaries)
-        if hasattr(self, 'collections'):
+        '''if hasattr(self, 'collections'):
             for collection in self.collections:
-                collection.update_object(repository)
+                collection.update_object(repository)'''
 
     # check for the existence of a local object in the repository
     def exists_in_repo(self, repository):


### PR DESCRIPTION
because collection creation is now a separate process, and also collections no longer point to members, it is not necessary for the loader to be touching the collection object in Fedora at all