### PR TITLE
LIBFCREPO-269. Add the METS metadata files to the issue.

### DIFF
--- a/classes/pcdm.py
+++ b/classes/pcdm.py
@@ -349,6 +349,7 @@ class Resource(object):
             related_object.graph.add(
                 (related_object.uri, pcdm.relatedObjectOf, self.uri)
                 )
+            related_object.update_relationship_triples()
 
     # add arbitrary additional triples provided in a file
     def add_extra_properties(self, triples_file, rdf_format):
@@ -452,10 +453,15 @@ class Component(Resource):
 
 class File(Resource):
 
-    def __init__(self, localpath):
+    def __init__(self, localpath, title=None):
         Resource.__init__(self)
         self.localpath = localpath
+        if title is not None:
+            self.title = title
+        else:
+            self.title = os.path.basename(self.localpath)
         self.graph.add((self.uri, rdf.type, pcdm.File))
+        self.graph.add((self.uri, dcterms.title, rdflib.Literal(self.title)))
 
     # upload a binary resource
     def create_nonrdf(self, repository):


### PR DESCRIPTION
Added as related objects of class fabio:Metadata, which then each have one pcdm:File of the actual XML. These files are represented by the class ndnp.MetadataFile, which adds fabio:MetadataDocument to their list of RDF types.

Also changed the pcdm.File constructor to take an optional title argument and use that (or the basename of the filepath) to set the dcterms:title in the file's metadata. This ensures that every pcdm:File has a title, not just ones that are created via the ndnp.File class.

https://issues.umd.edu/browse/LIBFCREPO-269