### PR TITLE
Refactor object updating process.

### DIFF
--- a/create_collection.py
+++ b/create_collection.py
@@ -25,7 +25,6 @@ def create_collection(fcrepo, name):
     try:
         collection = pcdm.Collection()
         collection.title = name
-        collection.graph.add( (collection.uri, pcdm.dcterms.title, rdflib.Literal(name)) )
         collection.create_object(fcrepo)
         collection.update_object(fcrepo)
         # commit transaction

--- a/load.py
+++ b/load.py
@@ -63,8 +63,6 @@ def load_item(fcrepo, item, args, extra=None):
         item.recursive_create(fcrepo, args.nobinaries)
         logger.info('Creating ordering proxies')
         item.create_ordering(fcrepo)
-        logger.info('Updating relationship triples')
-        item.update_relationship_triples()
 
         if extra:
             logger.info('Adding additional triples')


### PR DESCRIPTION
Each PCDM object now has a graph() method that constructs the RDF graph from its in-memory metadata. The update_object() method calls graph() just before sending the PATCH request to update the object, so all of the child and related objects should already have URIs in fcrepo. It is now the responsibility of each object to track and add its own relationships to its graph.

Also added "bibo:pageStart" and "bibo:pageEnd" properties to the Article objects.