### PR TITLE
LIBFCREPO-295. Added utility to list the URIs of all the components of an item.

### DIFF
--- a/classes/pcdm.py
+++ b/classes/pcdm.py
@@ -125,6 +125,17 @@ class Repository():
         self.logger.debug("%s %s", response.status_code, response.reason)
         return response
 
+    def recursive_get(self, url, traverse=[], **kwargs):
+        uris = {url}
+        response = self.get(url, headers={'Accept': 'text/turtle'}, **kwargs)
+        if response.status_code == 200:
+            graph = rdflib.Graph()
+            graph.parse(data=response.text, format='n3', publicID=url)
+            for (s, p, o) in graph:
+                if p in traverse:
+                    uris.update(self.recursive_get(str(o), traverse=traverse, **kwargs))
+        return uris
+
     def open_transaction(self, **kwargs):
         url = os.path.join(self.endpoint, 'fcr:tx')
         self.logger.info("Creating transaction")

--- a/list.py
+++ b/list.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+#-*- coding: utf-8 -*-
+
+import argparse
+import sys
+import yaml
+import logging
+import logging.config
+from datetime import datetime
+from classes import pcdm
+
+logger = logging.getLogger(__name__)
+
+def main():
+    '''Parse args and handle options.'''
+
+    parser = argparse.ArgumentParser(
+        description='Recursive object lister for Fedora 4.'
+        )
+
+    # Path to the repo config (endpoint, relpath, credentials, and WebAC paths)
+    parser.add_argument('-r', '--repo',
+                        help='Path to repository configuration file.',
+                        action='store',
+                        required=True
+                        )
+
+    args = parser.parse_args()
+
+    # configure logging
+    with open('config/logging.yml', 'r') as configfile:
+        logging_config = yaml.safe_load(configfile)
+        logfile = 'logs/read.py.{0}.log'.format(
+            datetime.utcnow().strftime('%Y%m%d%H%M%S')
+            )
+        logging_config['handlers']['file']['filename'] = logfile
+        logging_config['handlers']['console']['stream'] = 'ext://sys.stderr'
+        logging.config.dictConfig(logging_config)
+
+    # Load required repository config file and create repository object
+    with open(args.repo, 'r') as repoconfig:
+        fcrepo = pcdm.Repository(yaml.safe_load(repoconfig))
+        logger.info('Loaded repo configuration from {0}'.format(args.repo))
+
+    predicates = [pcdm.pcdm.hasMember, pcdm.pcdm.hasFile, pcdm.pcdm.hasRelatedObject]
+    for item_uri in sys.stdin:
+        for uri in fcrepo.recursive_get(item_uri.rstrip('\n'), traverse=predicates):
+            print(uri)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Uses recursive_get method of the Repository class to walk the objects in the repository and assemble a set of URI strings. The list.py utility reads a list of item URIs on STDIN and prints those URIs plus the URIs of all their components to STDOUT.

https://issues.umd.edu/browse/LIBFCREPO-295