### PR TITLE
LIBFCREPO-290. Add recursive option to delete.py script.

### DIFF
--- a/classes/pcdm.py
+++ b/classes/pcdm.py
@@ -124,7 +124,7 @@ class Repository():
             )
         self.logger.debug("%s %s", response.status_code, response.reason)
         return response
-    
+
     def delete(self, url, **kwargs):
         target_uri = self._insert_transaction_uri(url)
         self.logger.debug('DELETE {0}'.format(target_uri))
@@ -136,7 +136,7 @@ class Repository():
         return response
 
     def recursive_get(self, url, traverse=[], **kwargs):
-        uris = {url}
+        uris = {self._remove_transaction_uri(url)}
         response = self.get(url, headers={'Accept': 'text/turtle'}, **kwargs)
         if response.status_code == 200:
             graph = rdflib.Graph()


### PR DESCRIPTION
Pass it a comma-separated list of prefixed identifiers to set the predicates for it to traverse when it does a recursive_get. The recognized prefixes are the ones defined in the pcdm module's namespace manager. Full URIs may also be given, but must be written in N3 format like <http://pcdm.org/models#hasFile>

https://issues.umd.edu/browse/LIBFCREPO-290