### PR TITLE
LIBFCREPO-291

### DIFF
--- a/config/templates/batch.yml
+++ b/config/templates/batch.yml
@@ -1,5 +1,7 @@
 HANDLER:
 COLLECTION: 
 LOCAL_PATH: 
+LOG_LOCATION: 
+LOG_CONFIG: config/logging.yml
 MAPFILE: logs/mapfile.csv
 EXTRA: 

--- a/config/templates/batch.yml
+++ b/config/templates/batch.yml
@@ -3,5 +3,5 @@ COLLECTION:
 LOCAL_PATH: 
 LOG_LOCATION: 
 LOG_CONFIG: config/logging.yml
-MAPFILE: logs/mapfile.csv
+MAPFILE: mapfile.csv
 EXTRA: 


### PR DESCRIPTION
- make the log location part of batch configuration
- make the log configuration file path part of batch configuration
- update batch config template
- refactor load.py for consistency and (hopefully) greater clarity

respecting the log location specified in the batch config necessitated changing the order of the processing of configuration files, which in turn led to some refactoring for consistency of variable names and 'de-denting' of some long with/open blocks.