### PR TITLE
Fragment resources, unified create_object, and relpath overrides

### DIFF
--- a/classes/pcdm.py
+++ b/classes/pcdm.py
@@ -52,6 +52,7 @@ class Repository():
     def __init__(self, config):
         self.endpoint = config['REST_ENDPOINT']
         self.relpath = config['RELPATH']
+        self._path_stack = [ self.relpath ]
         self.fullpath = '/'.join(
             [p.strip('/') for p in (self.endpoint, self.relpath)]
             )
@@ -72,6 +73,18 @@ class Repository():
             self.server_cert = config['SERVER_CERT']
         else:
             self.server_cert = None
+
+    def at_path(self, relpath):
+        self._path_stack.append(self.relpath)
+        self.relpath = relpath
+        return self
+
+    def __enter__(self):
+        pass
+
+    def __exit__(self, type, value, traceback):
+        self.relpath = self._path_stack.pop()
+
 
     def is_reachable(self):
         response = self.head(self.fullpath)


### PR DESCRIPTION
Added support for:
* Creating resources with fragment identifiers
* Doing a PUT instead of a POST in the pcdm.Resource.create_object base class
* Temporary override of the repository relpath in a `with repo.at_path('foo')` block

These changes are all in support of modelling the OCR textblocks as Web Annotations. See https://issues.umd.edu/browse/LIBFCREPO-273