### PR TITLE
LIBFCREPO-332. Create OCR textblock annotations during load.

### DIFF
--- a/classes/ocr.py
+++ b/classes/ocr.py
@@ -1,0 +1,64 @@
+from lxml import etree
+
+ns = { "alto": "http://www.loc.gov/standards/alto/ns-v2#" }
+
+class ALTOResource(object):
+    def __init__(self, xmldoc, image_resolution):
+        self.xmldoc = xmldoc
+        unit = xmldoc.xpath('/alto:alto/alto:Description/alto:MeasurementUnit', namespaces=ns)[0].text
+        xres = image_resolution[0]
+        yres = image_resolution[1]
+
+        if unit == 'inch1200':
+            self.scale = (xres / 1200.0, yres / 1200.0)
+        elif unit == 'mm10':
+            self.scale = (xres / 254.0, yres / 254.0)
+        elif unit == 'pixel':
+            self.scale = (1, 1)
+        else:
+            raise Exception("Unknown MeasurementUnit " + unit)
+
+    def textblock(self, id):
+        return TextBlock(self.xmldoc.xpath("//alto:TextBlock[@ID=$id]", id=id, namespaces=ns)[0])
+
+class Region(object):
+    def __init__(self, element):
+        self.element = element
+        self.id = self.element.get('ID')
+        self.hpos = int(self.element.get('HPOS'))
+        self.vpos = int(self.element.get('VPOS'))
+        self.width = int(self.element.get('WIDTH'))
+        self.height = int(self.element.get('HEIGHT'))
+
+    def xywh(self, scale):
+        xscale = scale[0]
+        yscale = scale[1]
+        x = round(self.hpos   * xscale)
+        y = round(self.vpos   * yscale)
+        w = round(self.width  * xscale)
+        h = round(self.height * yscale)
+
+        return (x, y, w, h)
+
+    def bbox(self, scale):
+        (x, y, w, h) = self.xywh(scale)
+        return (x, y, x+w, y+h)
+
+class TextBlock(Region):
+    def lines(self):
+        for node in self.element.xpath('alto:TextLine', namespaces=ns):
+            yield TextLine(node)
+
+    def text(self):
+        return "\n".join([ line.text() for line in self.lines() ])
+
+class TextLine(Region):
+    def text(self):
+        text = ''
+        for node in self.element.xpath('alto:String|alto:SP|alto:HYP', namespaces=ns):
+            tag = etree.QName(node.tag)
+            if tag.localname == 'SP':
+                text += ' '
+            else:
+                text += node.get('CONTENT')
+        return text

--- a/classes/pcdm.py
+++ b/classes/pcdm.py
@@ -714,3 +714,15 @@ class FragmentSelector(Resource):
         if self.conforms_to is not None:
             graph.add((self.uri, dcterms.conformsTo, self.conforms_to))
         return graph
+
+class XPathSelector(Resource):
+    def __init__(self, value):
+        super(XPathSelector, self).__init__()
+        self.value = value
+        self.title = self.value
+
+    def graph(self):
+        graph = super(XPathSelector, self).graph()
+        graph.add((self.uri, rdf.value, rdflib.Literal(self.value)))
+        graph.add((self.uri, rdf.type, oa.XPathSelector))
+        return graph

--- a/classes/pcdm.py
+++ b/classes/pcdm.py
@@ -256,6 +256,7 @@ class Resource(object):
         self.uri = rdflib.URIRef(uri)
         self.linked_objects = []
         self.fragments = []
+        self.annotations = None
         self.extra = rdflib.Graph()
         self.created = False
         self.updated = False
@@ -368,8 +369,8 @@ class Resource(object):
                 subject = '<>'
             triples.append("{0} {1} {2}.".format(
                 subject,
-            graph.namespace_manager.normalizeUri(p),
-            o.n3(graph.namespace_manager)
+                graph.namespace_manager.normalizeUri(p),
+                o.n3(graph.namespace_manager)
                 ))
 
         query = prolog + "INSERT DATA {{{0}}}".format("\n".join(triples))
@@ -406,6 +407,9 @@ class Resource(object):
             self.update_object(repository)
             for (rel, obj) in self.linked_objects:
                 obj.recursive_update(repository)
+            if self.annotations is not None:
+                for annotation in self.annotations:
+                    annotation.recursive_update(repository)
 
     # check for the existence of a local object in the repository
     def exists_in_repo(self, repository):
@@ -461,6 +465,7 @@ class Item(Resource):
         super(Item, self).__init__()
         self.first = None
         self.last = None
+        self.annotations = []
 
     def graph(self):
         graph = super(Item, self).graph()
@@ -498,6 +503,11 @@ class Item(Resource):
                 proxy.next = proxies[position + 1]
 
             proxy.update_object(repository)
+
+    def create_annotations(self, repository):
+        with repository.at_path('annotations'):
+            for annotation in self.annotations:
+                annotation.recursive_create(repository)
 
 #============================================================================
 # PCDM COMPONENT-OBJECT
@@ -633,3 +643,74 @@ class Proxy(Resource):
     def create_object(self, repository, **kwargs):
         uri='/'.join([p.strip('/') for p in (self.proxy_for.uri, self.proxy_in.uuid)])
         super(Proxy, self).create_object(repository, uri=uri, **kwargs)
+
+# Annotation resources
+
+class Annotation(Resource):
+    def __init__(self):
+        super(Annotation, self).__init__()
+        self.motivation = None
+
+    def add_body(self, body):
+        self.linked_objects.append((oa.hasBody, body))
+        self.title = body.title
+        body.annotation = self
+
+    def add_target(self, target):
+        self.linked_objects.append((oa.hasTarget, target))
+        target.annotation = self
+
+    def graph(self):
+        graph = super(Annotation, self).graph()
+        graph.add((self.uri, rdf.type, oa.Annotation))
+        if self.motivation is not None:
+            graph.add((self.uri, oa.motivatedBy, self.motivation))
+        return graph
+
+class TextualBody(Resource):
+    def __init__(self, value, content_type):
+        super(TextualBody, self).__init__()
+        self.value = value
+        self.content_type = content_type
+        if len(self.value) <= 25:
+            self.title = self.value
+        else:
+            self.title = self.value[:24] + '…'
+
+    def graph(self):
+        graph = super(TextualBody, self).graph()
+        graph.add((self.uri, rdf.value, rdflib.Literal(self.value)))
+        graph.add((self.uri, dcterms['format'], rdflib.Literal(self.content_type)))
+        graph.add((self.uri, rdf.type, oa.TextualBody))
+        return graph
+
+class SpecificResource(Resource):
+    def __init__(self, source):
+        super(SpecificResource, self).__init__()
+        self.source = source
+
+    def add_selector(self, selector):
+        self.title = selector.title
+        self.linked_objects.append((oa.hasSelector, selector))
+        selector.annotation = self
+
+    def graph(self):
+        graph = super(SpecificResource, self).graph()
+        graph.add((self.uri, oa.hasSource, self.source.uri))
+        graph.add((self.uri, rdf.type, oa.SpecificResource))
+        return graph
+
+class FragmentSelector(Resource):
+    def __init__(self, value, conforms_to=None):
+        super(FragmentSelector, self).__init__()
+        self.value = value
+        self.conforms_to = conforms_to
+        self.title = self.value
+
+    def graph(self):
+        graph = super(FragmentSelector, self).graph()
+        graph.add((self.uri, rdf.value, rdflib.Literal(self.value)))
+        graph.add((self.uri, rdf.type, oa.FragmentSelector))
+        if self.conforms_to is not None:
+            graph.add((self.uri, dcterms.conformsTo, self.conforms_to))
+        return graph

--- a/handler/ndnp.py
+++ b/handler/ndnp.py
@@ -65,6 +65,9 @@ namespace_manager.bind('oa', oa, override=False)
 sc = Namespace('http://www.shared-canvas.org/ns/')
 namespace_manager.bind('sc', sc, override=False)
 
+prov = Namespace('http://www.w3.org/ns/prov#')
+namespace_manager.bind('prov', prov, override=False)
+
 
 #============================================================================
 # METADATA MAPPING
@@ -395,11 +398,15 @@ class TextblockOnPage(pcdm.Annotation):
             "xywh={0}".format(xywh),
             rdflib.URIRef('http://www.w3.org/TR/media-frags/')
             )
+        xpath_selector = pcdm.XPathSelector("//*[@ID='{0}']".format(textblock.id))
+        ocr_resource = pcdm.SpecificResource(page.ocr_file)
+        ocr_resource.add_selector(xpath_selector)
+        body.linked_objects.append((prov.wasDerivedFrom, ocr_resource))
         self.add_body(body)
         self.add_target(target)
         self.motivation = sc.painting
         target.add_selector(selector)
-        self.fragments = [body, target, selector]
+        self.fragments = [body, target, selector, ocr_resource, xpath_selector]
 
 class IssueMetadata(pcdm.Component):
     '''additional metadata about an issue'''
@@ -472,6 +479,7 @@ class Page(pcdm.Component):
 
                 # TODO: read in resolution from issue METS data
                 image_resolution = (400, 400)
+                self.ocr_file = file
                 self.ocr = ocr.ALTOResource(tree, image_resolution)
 
     def graph(self):

--- a/handler/ndnp.py
+++ b/handler/ndnp.py
@@ -394,7 +394,7 @@ class Issue(pcdm.Item):
 class TextblockOnPage(pcdm.Annotation):
     def __init__(self, textblock, page, article=None):
         super(TextblockOnPage, self).__init__()
-        body = pcdm.TextualBody(textblock.text(), 'text/plain')
+        body = pcdm.TextualBody(textblock.text(scale=page.ocr.scale), 'text/plain')
         if article is not None:
             body.linked_objects.append((dcterms.isPartOf, article))
         target = pcdm.SpecificResource(page)

--- a/load.py
+++ b/load.py
@@ -63,6 +63,8 @@ def load_item(fcrepo, item, args, extra=None):
         item.recursive_create(fcrepo)
         logger.info('Creating ordering proxies')
         item.create_ordering(fcrepo)
+        logger.info('Creating annotations')
+        item.create_annotations(fcrepo)
 
         if extra:
             logger.info('Adding additional triples')


### PR DESCRIPTION
* Include word-level coordinates embedded in the plain text.
* Use Web Annotations structure.
* Use the prov:wasDerivedFrom predicate to connect the oa:TextualBody of the OCR text back to the XML element in the ALO file it was generated from

https://issues.umd.edu/browse/LIBFCREPO-332