### PR TITLE
LIBFCREPO-332. Extract all text blocks from the page.

### DIFF
--- a/classes/ocr.py
+++ b/classes/ocr.py
@@ -18,6 +18,10 @@ class ALTOResource(object):
         else:
             raise Exception("Unknown MeasurementUnit " + unit)
 
+    def textblocks(self):
+        for node in self.xmldoc.xpath("//alto:TextBlock", namespaces=ns):
+            yield TextBlock(node)
+
     def textblock(self, id):
         return TextBlock(self.xmldoc.xpath("//alto:TextBlock[@ID=$id]", id=id, namespaces=ns)[0])
 

--- a/handler/ndnp.py
+++ b/handler/ndnp.py
@@ -406,7 +406,7 @@ class TextblockOnPage(pcdm.Annotation):
         xpath_selector = pcdm.XPathSelector('//*[@ID="{0}"]'.format(textblock.id))
         ocr_resource = pcdm.SpecificResource(page.ocr_file)
         ocr_resource.add_selector(xpath_selector)
-        body.linked_objects.append((prov.wasDerivedFrom, ocr_resource))
+        self.linked_objects.append((prov.wasDerivedFrom, ocr_resource))
         self.add_body(body)
         self.add_target(target)
         self.motivation = sc.painting


### PR DESCRIPTION
Drive the extraction from the page ALTO XML and not the article-level segmentation METS file. This will create text block annotations for all text on the pages, not just the articles. THus it will include mastheads, advertisements, and any other non-article blocks.

https://issues.umd.edu/browse/LIBFCREPO-332