### PR TITLE
LIBFCREPO-331. OCR extraction tool.

### DIFF
--- a/classes/pcdm.py
+++ b/classes/pcdm.py
@@ -53,6 +53,9 @@ namespace_manager.bind('sc', sc, override=False)
 ldp = Namespace('http://www.w3.org/ns/ldp#')
 namespace_manager.bind('ldp', ldp, override=False)
 
+prov = Namespace('http://www.w3.org/ns/prov#')
+namespace_manager.bind('prov', prov, override=False)
+
 #============================================================================
 # REPOSITORY (REPRESENTING AN FCREPO INSTANCE)
 #============================================================================
@@ -175,6 +178,15 @@ class Repository():
                     for (uri, graph) in self.recursive_get(
                         str(o), traverse=traverse, **kwargs):
                         yield (uri, graph)
+
+    def get_graph(self, url):
+        response = self.get(url, headers={'Accept': 'text/turtle'}, stream=True)
+        if response.status_code != 200:
+            self.logger.error("Unable to get text/turtle representation of {0}".format(url))
+            raise RESTAPIException(response)
+        graph = rdflib.Graph()
+        graph.parse(source=response.raw, format='turtle')
+        return graph
 
     def open_transaction(self, **kwargs):
         url = os.path.join(self.endpoint, 'fcr:tx')
@@ -407,9 +419,6 @@ class Resource(object):
             self.update_object(repository)
             for (rel, obj) in self.linked_objects:
                 obj.recursive_update(repository)
-            if self.annotations is not None:
-                for annotation in self.annotations:
-                    annotation.recursive_update(repository)
 
     # check for the existence of a local object in the repository
     def exists_in_repo(self, repository):
@@ -509,6 +518,10 @@ class Item(Resource):
             for annotation in self.annotations:
                 annotation.recursive_create(repository)
 
+    def update_annotations(self, repository):
+        for annotation in self.annotations:
+            annotation.recursive_update(repository)
+
 #============================================================================
 # PCDM COMPONENT-OBJECT
 #============================================================================
@@ -529,14 +542,28 @@ class Component(Resource):
 #============================================================================
 
 class File(Resource):
+    @classmethod
+    def from_localpath(cls, localpath, title=None):
+        return cls(
+            stream=open(localpath, 'rb'),
+            filename=os.path.basename(localpath),
+            mimetype=mimetypes.guess_type(localpath)[0],
+            title=title
+            )
 
-    def __init__(self, localpath, title=None):
+    def __init__(self, stream, filename, mimetype, title=None):
         super(File, self).__init__()
-        self.localpath = localpath
+        self.stream = stream
+        self.filename = filename
+        self.mimetype = mimetype
         if title is not None:
             self.title = title
         else:
-            self.title = os.path.basename(self.localpath)
+            self.title = self.filename
+
+    def __del__(self):
+        # close the stream when this object is destroyed
+        self.stream.close()
 
     def graph(self):
         graph = super(File, self).graph()
@@ -556,12 +583,10 @@ class File(Resource):
             return False
 
         checksum = self.sha1()
-        mimetype = mimetypes.guess_type(self.localpath)[0]
-        self.filename = os.path.basename(self.localpath)
         self.logger.info("Loading {0}".format(self.filename))
-        with open(self.localpath, 'rb') as binaryfile:
-            data = binaryfile.read()
-        headers = {'Content-Type': mimetype,
+        self.stream.seek(0)
+        data = self.stream.read()
+        headers = {'Content-Type': self.mimetype,
                    'Digest': 'sha1={0}'.format(checksum),
                    'Content-Disposition':
                         'attachment; filename="{0}"'.format(self.filename)
@@ -588,12 +613,12 @@ class File(Resource):
     def sha1(self):
         BUF_SIZE = 65536
         sha1 = hashlib.sha1()
-        with open(self.localpath, 'rb') as f:
-            while True:
-                data = f.read(BUF_SIZE)
-                if not data:
-                    break
-                sha1.update(data)
+        self.stream.seek(0)
+        while True:
+            data = self.stream.read(BUF_SIZE)
+            if not data:
+                break
+            sha1.update(data)
         return sha1.hexdigest()
 
 #============================================================================

--- a/extractocr.py
+++ b/extractocr.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+
+import argparse
+import sys
+import yaml
+import logging
+import logging.config
+from datetime import datetime
+from classes import pcdm,ocr
+from handler import ndnp
+import rdflib
+from rdflib import RDF
+from lxml import etree as ET
+
+logger = logging.getLogger(__name__)
+
+# stub page object
+class Page(object):
+    def __init__(self, uri, ocr_resource, ocr_file):
+        self.uri = uri
+        self.ocr = ocr_resource
+        self.ocr_file = ocr_file
+
+# sub file object
+class File(object):
+    def __init__(self, uri):
+        self.uri = uri
+
+def main():
+    '''Parse args and handle options.'''
+
+    parser = argparse.ArgumentParser(
+        description='Extract OCR text and create annotations.'
+        )
+
+    # Path to the repo config (endpoint, relpath, credentials, and WebAC paths)
+    parser.add_argument('-r', '--repo',
+                        help='Path to repository configuration file.',
+                        action='store',
+                        required=True
+                        )
+
+    parser.add_argument('uris', nargs='+',
+                        help='One or more repository URIs to extract text from.'
+                        )
+
+    args = parser.parse_args()
+
+    # configure logging
+    with open('config/logging.yml', 'r') as configfile:
+        logging_config = yaml.safe_load(configfile)
+        logfile = 'logs/extractocr.py.{0}.log'.format(
+            datetime.utcnow().strftime('%Y%m%d%H%M%S')
+            )
+        logging_config['handlers']['file']['filename'] = logfile
+        logging.config.dictConfig(logging_config)
+
+    # Load required repository config file and create repository object
+    with open(args.repo, 'r') as repoconfig:
+        fcrepo = pcdm.Repository(yaml.safe_load(repoconfig))
+        logger.info('Loaded repo configuration from {0}'.format(args.repo))
+
+    with fcrepo.at_path('/annotations'):
+        for issue_uri in args.uris:
+            fcrepo.open_transaction()
+            issue_graph = fcrepo.get_graph(issue_uri)
+            issue_uri = rdflib.URIRef(fcrepo._insert_transaction_uri(issue_uri))
+            for member_uri in issue_graph.objects(subject=issue_uri, predicate=pcdm.pcdm.hasMember):
+                member_graph = fcrepo.get_graph(member_uri)
+                if (member_uri, RDF.type, ndnp.ndnp.Page) in member_graph:
+                    page = ndnp.Page.from_repository(fcrepo, member_uri, graph=member_graph)
+                    logger.info("Creating annotations for page {0}".format(page.title))
+                    for annotation in page.textblocks():
+                        annotation.create_object(fcrepo)
+                        annotation.update_object(fcrepo)
+            fcrepo.commit_transaction()
+
+
+if __name__ == "__main__":
+    main()

--- a/load.py
+++ b/load.py
@@ -63,8 +63,9 @@ def load_item(fcrepo, item, args, extra=None):
         item.recursive_create(fcrepo)
         logger.info('Creating ordering proxies')
         item.create_ordering(fcrepo)
-        logger.info('Creating annotations')
-        item.create_annotations(fcrepo)
+        if not args.noannotations:
+            logger.info('Creating annotations')
+            item.create_annotations(fcrepo)
 
         if extra:
             logger.info('Adding additional triples')
@@ -76,6 +77,9 @@ def load_item(fcrepo, item, args, extra=None):
 
         logger.info('Updating item and components')
         item.recursive_update(fcrepo)
+        if not args.noannotations:
+            logger.info('Updating annotations')
+            item.update_annotations(fcrepo)
 
         # commit transaction
         logger.info('Committing transaction')
@@ -153,6 +157,11 @@ def main():
 
     parser.add_argument('-q', '--quiet',
                         help='decrease the verbosity of the status output',
+                        action='store_true'
+                        )
+
+    parser.add_argument('--noannotations',
+                        help='iterate without loading annotations (e.g. OCR)',
                         action='store_true'
                         )
 


### PR DESCRIPTION
Created extractocr.py script that takes a 1 or more issue URIs and creates web annotations in fcrepo for each OCR textblock in the original ALTO XML files currently stored in fcrepo. Required refactoring of some of the ndnp and pcdm classes to separate the code to parse the METS XML from the constructor, so that objects could be created from the repository instead. Also redesigned pcdm.File class around streams instead of file names. Each issue's annotations are created in a separate transaction. Added "--noannotations" flag to load.py to do a batch load without creating annotations.

https://issues.umd.edu/browse/LIBFCREPO-331