### PR TITLE
LIBFCREPO-366. Added exception handling to extractocr.py.

### DIFF
--- a/classes/util.py
+++ b/classes/util.py
@@ -1,17 +1,15 @@
 import os
 import csv
 
-class CompletedLog():
+class ItemLog():
     def __init__(self, filename, fieldnames, keyfield):
         self.filename = filename
         self.fieldnames = fieldnames
         self.keyfield = keyfield
-        self.skip_list = set()
+        self.item_keys = set()
         self.fh = None
         self.writer = None
 
-        # open filename, if it exists, and read completed files into list
-        completed_items = []
         if not os.path.isfile(self.filename):
             with open(self.filename, 'w', 1) as fh:
                 writer = csv.DictWriter(fh, fieldnames=self.fieldnames)
@@ -26,7 +24,7 @@ class CompletedLog():
 
                 # read the data from the existing file
                 for row in reader:
-                    self.skip_list.add(row[self.keyfield])
+                    self.item_keys.add(row[self.keyfield])
 
     def get_writer(self):
         if self.fh is None:
@@ -37,13 +35,13 @@ class CompletedLog():
 
     def writerow(self, row):
         self.get_writer().writerow(row)
-        self.skip_list.add(row[self.keyfield])
+        self.item_keys.add(row[self.keyfield])
 
     def __contains__(self, other):
-        return other in self.skip_list
+        return other in self.item_keys
 
     def __len__(self):
-        return len(self.skip_list)
+        return len(self.item_keys)
 
     def __del__(self):
         if self.fh is not None:

--- a/extractocr.py
+++ b/extractocr.py
@@ -11,8 +11,32 @@ from handler import ndnp
 import rdflib
 from rdflib import RDF
 from lxml import etree as ET
+import os
+import csv
 
 logger = logging.getLogger(__name__)
+
+def extract(fcrepo, uri):
+    fcrepo.open_transaction()
+    try:
+        logger.info("Getting {0} from repository".format(uri))
+        page = ndnp.Page.from_repository(fcrepo, uri)
+        logger.info("Creating annotations for page {0}".format(page.title))
+        for annotation in page.textblocks():
+            annotation.create_object(fcrepo)
+            annotation.update_object(fcrepo)
+
+        fcrepo.commit_transaction()
+        return True
+
+    except (pcdm.RESTAPIException, ndnp.DataReadException) as e:
+        # if anything fails during item creation or commiting the transaction
+        # attempt to rollback the current transaction
+        # failures here will be caught by the main loop's exception handler
+        # and should trigger a system exit
+        logger.error("Item creation failed: {0}".format(e))
+        fcrepo.rollback_transaction()
+        logger.warn('Transaction rolled back. Continuing load.')
 
 def main():
     '''Parse args and handle options.'''
@@ -57,22 +81,34 @@ def main():
 
     logger.info('Found {0} completed items'.format(len(completed)))
 
+    skipfile = os.path.join('logs/skipped.csv')
+    sfile = open(skipfile, 'w+', 1)
+    skip_writer = csv.DictWriter(sfile, fieldnames=['uri', 'timestamp'])
+    skip_writer.writeheader()
+
     with fcrepo.at_path('/annotations'):
         for uri in args.uris:
             if uri in completed:
                 continue
 
-            fcrepo.open_transaction()
-            page = ndnp.Page.from_repository(fcrepo, uri)
-            logger.info("Creating annotations for page {0}".format(page.title))
-            for annotation in page.textblocks():
-                annotation.create_object(fcrepo)
-                annotation.update_object(fcrepo)
-            fcrepo.commit_transaction()
-            completed.writerow({
+            is_extracted = False
+            try:
+                is_extracted = extract(fcrepo, uri)
+            except pcdm.RESTAPIException as e:
+                logger.error(
+                    "Unable to commit or rollback transaction, aborting"
+                    )
+                sys.exit(1)
+
+            row = {
                 'uri': uri,
                 'timestamp': str(datetime.utcnow())
-                })
+                }
+
+            if is_extracted:
+                completed.writerow(row)
+            else:
+                skip_writer.writerow(row)
 
 if __name__ == "__main__":
     main()

--- a/handler/ndnp.py
+++ b/handler/ndnp.py
@@ -570,9 +570,7 @@ class File(pcdm.File):
         head_res = repo.head(file_uri)
         if 'describedby' in head_res.links:
             rdf_uri = head_res.links['describedby']['url']
-            file_res = repo.get(rdf_uri, headers={'Accept': 'text/turtle'})
-            file_graph = rdflib.Graph()
-            file_graph.parse(data=file_res.text, format='turtle')
+            file_graph = repo.get_graph(rdf_uri)
 
             title = file_graph.value(subject=file_uri, predicate=dcterms.title)
             mimetype = file_graph.value(subject=file_uri,


### PR DESCRIPTION
* Will record the skipped item and move on to the next one if there is a non-fatal error while attempting to extract OCR text and create annotations.
* Renamed CompletedLog to ItemLog, and reuse it to also record the skipped items for a run of load.py or extractocr.py. Include the timestamp and program name in the skipped.csv filename.

https://issues.umd.edu/browse/LIBFCREPO-366