### PR TITLE
LIBFCREPO-421. Move from_repository method to pcdm.Collection.

### DIFF
--- a/classes/pcdm.py
+++ b/classes/pcdm.py
@@ -450,6 +450,24 @@ class File(Resource):
 
 class Collection(Resource):
 
+    @classmethod
+    def from_repository(cls, repo, uri):
+        graph = repo.get_graph(uri)
+        collection = cls()
+        collection.uri = URIRef(uri)
+
+        # mark as created and updated so that the create_object and update_object
+        # methods doesn't try try to modify it
+        collection.created = True
+        collection.updated = True
+
+        # default title is the URI
+        collection.title = str(collection.uri)
+        for o in graph.objects(subject=collection.uri, predicate=dcterms.title):
+            collection.title = str(o)
+
+        return collection
+
     def __init__(self):
         super(Collection, self).__init__()
         self.title = None

--- a/handler/ndnp.py
+++ b/handler/ndnp.py
@@ -93,7 +93,7 @@ class Batch():
             raise ConfigException(
                 'Missing required key COLLECTION in batch config'
                 )
-        self.collection = Collection.from_repo_uri(repo, collection_uri)
+        self.collection = Collection.from_repository(repo, collection_uri)
 
         self.fieldnames = ['aggregation', 'sequence', 'uri']
 
@@ -597,29 +597,6 @@ class Collection(pcdm.Collection):
 
     def __init__(self):
         super(Collection, self).__init__()
-
-    @classmethod
-    def from_repo_uri(klass, repository, uri):
-        response = repository.get(uri, headers={'Accept': 'application/rdf+xml'})
-        if response.status_code == 200:
-            graph = Graph().parse(data=response.text)
-            collection = klass()
-            collection.uri = URIRef(uri)
-            # mark as created and updated so that the create_object and update_object
-            # methods doesn't try try to modify it
-            collection.created = True
-            collection.updated = True
-
-            # default title is the URI
-            collection.title = str(collection.uri)
-            for o in graph.objects(subject=collection.uri, predicate=dcterms.title):
-                collection.title = str(o)
-        else:
-            raise ConfigException(
-                "Collection URI {0} could not be reached.".format(collection.uri)
-                )
-
-        return collection
 
 
 #============================================================================


### PR DESCRIPTION
Move the from_repository class method into the pcdm.Collection base class, since it is very generic and useful for things other than the NDNP handler.

https://issues.umd.edu/browse/LIBFCREPO-421